### PR TITLE
Collation in MySQL, PostgreSQL and SQLite adaptors.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -70,6 +70,7 @@ module ActiveRecord
             column_options[:after] = o.after
             column_options[:auto_increment] = o.auto_increment
             column_options[:primary_key] = o.primary_key
+            column_options[:collation] = o.collation if o.collation
             column_options
           end
 
@@ -85,6 +86,8 @@ module ActiveRecord
             if options[:primary_key] == true
               sql << " PRIMARY KEY"
             end
+
+            sql << collation_sql(options[:collation])
             sql
           end
 
@@ -103,6 +106,10 @@ module ActiveRecord
                 Supported values are: :nullify, :cascade, :restrict
               MSG
             end
+          end
+
+          def collation_sql(collation)
+            collation.present? ? " COLLATE \"#{ collation }\"" : ''
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     # are typically created by methods in TableDefinition, and added to the
     # +columns+ attribute of said TableDefinition object, in order to be used
     # for generating a number of table creation or table changing SQL statements.
-    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :sql_type) #:nodoc:
+    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :sql_type, :collation) #:nodoc:
 
       def primary_key?
         primary_key || type.to_sym == :primary_key
@@ -433,6 +433,7 @@ module ActiveRecord
         column.after       = options[:after]
         column.auto_increment = options[:auto_increment]
         column.primary_key = type == :primary_key || options[:primary_key]
+        column.collation   = options[:collation]
         column
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -35,15 +35,21 @@ module ActiveRecord
         default = schema_default(column) if column.has_default?
         spec[:default]   = default unless default.nil?
 
+        spec[:collation] = quoted_collation(column.collation) if column.collation.present?
+
         spec
       end
 
       # Lists the valid migration options
       def migration_keys
-        [:name, :limit, :precision, :scale, :default, :null]
+        [:name, :limit, :precision, :scale, :default, :null, :collation]
       end
 
       private
+
+      def quoted_collation(collation)
+        "\"#{ collation }\""
+      end
 
       def schema_type(column)
         column.type.to_s

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -387,8 +387,8 @@ module ActiveRecord
         end
       end
 
-      def new_column(name, default, sql_type_metadata = nil, null = true)
-        Column.new(name, default, sql_type_metadata, null)
+      def new_column(name, default, sql_type_metadata = nil, null = true, collation = nil)
+        Column.new(name, default, sql_type_metadata, null, nil, collation)
       end
 
       def lookup_cast_type(sql_type) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -342,8 +342,8 @@ module ActiveRecord
         raise NotImplementedError
       end
 
-      def new_column(field, default, sql_type_metadata = nil, null = true) # :nodoc:
-        Column.new(field, default, sql_type_metadata, null)
+      def new_column(field, default, sql_type_metadata = nil, null = true, default_function = nil, collation = nil) # :nodoc:
+        Column.new(field, default, sql_type_metadata, null, default_function, collation)
       end
 
       # Must return the MySQL error number from the exception, if the exception has an
@@ -567,7 +567,7 @@ module ActiveRecord
             field_name = set_field_encoding(field[:Field])
             sql_type = field[:Type]
             type_metadata = fetch_type_metadata(sql_type, field[:Collation], field[:Extra])
-            new_column(field_name, field[:Default], type_metadata, field[:Null] == "YES")
+            new_column(field_name, field[:Default], type_metadata, field[:Null] == "YES", nil, field[:Collation])
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?\z/
       end
 
-      attr_reader :name, :null, :sql_type_metadata, :default, :default_function
+      attr_reader :name, :null, :sql_type_metadata, :default, :default_function, :collation
 
       delegate :precision, :scale, :limit, :type, :sql_type, to: :sql_type_metadata, allow_nil: true
 
@@ -22,13 +22,14 @@ module ActiveRecord
       # +default+ is the type-casted default value, such as +new+ in <tt>sales_stage varchar(20) default 'new'</tt>.
       # +sql_type_metadata+ is various information about the type of the column
       # +null+ determines if this column allows +NULL+ values.
-      def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil)
-        @name = name
-        @sql_type_metadata = sql_type_metadata
-        @null = null
-        @default = default
-        @default_function = default_function
-        @table_name = nil
+      def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil, collation = nil)
+        @name               = name
+        @sql_type_metadata  = sql_type_metadata
+        @null               = null
+        @default            = default
+        @default_function   = default_function
+        @collation          = collation
+        @table_name         = nil
       end
 
       def has_default?

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -772,9 +772,12 @@ module ActiveRecord
         def column_definitions(table_name) # :nodoc:
           exec_query(<<-end_sql, 'SCHEMA').rows
               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
-                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
+                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid,
+                     a.atttypmod, c.collname
                 FROM pg_attribute a LEFT JOIN pg_attrdef d
                   ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+                LEFT JOIN pg_collation c
+                  ON a.attcollation = c.oid
                WHERE a.attrelid = '#{quote_table_name(table_name)}'::regclass
                  AND a.attnum > 0 AND NOT a.attisdropped
                ORDER BY a.attnum


### PR DESCRIPTION
Add collation on columns.

Give migration support in
1. create_table
2. add_column
3. change_column

Update schema.rb
